### PR TITLE
Add minimum and maximum required versions

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,7 +7,9 @@ While it is possible to manually change email templates within ownCloud, this ap
 </description>
 	<licence>AGPL</licence>
 	<author>Jörn Dreyer</author>
-	<requiremin>7</requiremin>
+	<dependencies>
+		<owncloud min-version="9.0" max-version="9.0" />
+	</dependencies>
 	<shipped>true</shipped>
 	<default_enable/>
 </info>


### PR DESCRIPTION
Fixes "This app has no minimum ownCloud version assigned. This will be an error in ownCloud 11 and later."

![2016-02-05_14-55-56](https://cloud.githubusercontent.com/assets/878997/12848191/92d070ba-cc18-11e5-99e7-ea300b7a2517.png)
