### PR TITLE
Fix wrong path to lost password template

### DIFF
--- a/lib/mailtemplate.php
+++ b/lib/mailtemplate.php
@@ -170,7 +170,7 @@ class MailTemplate extends \OC_Template {
 			'core/templates/altmail.php' => $l10n->t('Sharing email - public link shares (plain text fallback)'),
 			'core/templates/internalmail.php' => $l10n->t('Sharing email (HTML)'),
 			'core/templates/internalaltmail.php' => $l10n->t('Sharing email (plain text fallback)'),
-			'core/lostpassword/templates/email.php' => $l10n->t('Lost password mail'),
+			'core/templates/lostpassword/email.php' => $l10n->t('Lost password mail'),
 			'settings/templates/email.new_user.php' => $l10n->t('New user email (HTML)'),
 			'settings/templates/email.new_user_plain_text.php' => $l10n->t('New user email (plain text fallback)'),
 		);


### PR DESCRIPTION
* [x] approval by @karlitschek pending
* backport of #42

cc @cmonteroluque I would like to have this in 9.0.2 as an easy and minimal fix. Is this okay?

cc @michaelstingl 

