### PR TITLE
Inform user if there is no theme active

### DIFF
--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -6,6 +6,7 @@
 ?>
 <div class="section" id="mailTemplateSettings" >
 	<h2 class="app-name"><?php p($l->t('Mail Templates'));?></h2>
+	<?php if (count($_['themeNames'])): ?>
 	<div class="actions">
 		<div>
 			<label for="mts-theme"><?php p($l->t('Theme'));?></label>
@@ -33,4 +34,8 @@
 		<button class="save"><?php p($l->t('Save'));?></button>
 		<span id="mts-msg" class="msg"></span>
 	</div>
+	<?php else: ?>
+		<p><?php p($l->t('You need to activate own theme to edit mail templates.')) ?></p>
+		<p><?php print_unescaped($l->t('How to <a target="_blank" rel="noreferrer" href="%s">create a theme</a>.', [link_to_docs('developer-theming')])); ?></p>
+	<?php endif; ?>
 </div>


### PR DESCRIPTION
Fixes #58 

"create a theme" is a link to https://doc.owncloud.org/server/10.0/developer_manual/core/theming.html 

![no-theme](https://user-images.githubusercontent.com/991300/34172886-92812c88-e504-11e7-952a-067c351e593c.png)
