### PR TITLE
[stable10] Only test against core stable10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - 7.1
 env:
   global:
-    - CORE_BRANCH=master
+    - CORE_BRANCH=stable10
   matrix:
     - DB=sqlite
 


### PR DESCRIPTION
It does not make sense to try and test a ``stable10`` branch of an app against ``core`` ``master`` that has moved forward.