### PR TITLE
Refactor TemplateEditor, add footer templates and templates from notifications app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ script:
   - sh -c "if [ '$DB' = 'sqlite' ]; then ant test; fi"
 
   # Run phpunit tests
-  # - cd tests
-  # - phpunit --configuration phpunit.xml
+  - cd tests/unit
+  - ../../../../lib/composer/bin/phpunit --configuration phpunit.xml
 
   # Create coverage report
   # - wget https://scrutinizer-ci.com/ocular.phar

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ For more information, please read the [ownCloud Documentation](https://doc.owncl
 	<screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/templateeditor/template_editor.jpg</screenshot>
 	<namespace>TemplateEditor</namespace>
 	<dependencies>
-		<owncloud min-version="10.0.3" max-version="10.1" />
+		<owncloud min-version="10.0.8" max-version="10.1" />
 	</dependencies>
 	<default_enable/>
 	<website>https://github.com/owncloud/templateeditor/</website>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -23,6 +23,7 @@
 
 namespace OCA\TemplateEditor\AppInfo;
 
+use OC\Helper\EnvironmentHelper;
 use OCA\TemplateEditor\Controller\AdminSettingsController;
 use OCA\TemplateEditor\TemplateEditor;
 use OCP\AppFramework\App;
@@ -39,7 +40,12 @@ class Application extends App {
 		$container = $this->getContainer();
 
 		$container->registerService('TemplateEditor', function (IAppContainer $container) {
-			return new TemplateEditor($container->query('ThemeService'));
+			return new TemplateEditor(
+				$container->query('ThemeService'),
+				$container->query('AppManager'),
+				new EnvironmentHelper(),
+				\OC::$server->getL10NFactory()->get('templateeditor')
+			);
 		});
 
 		$container->registerService('AdminSettingsController', function(IAppContainer $container) {

--- a/lib/TemplateEditor.php
+++ b/lib/TemplateEditor.php
@@ -107,6 +107,15 @@ class TemplateEditor {
 				$this->l10n->t('New user email (plain text fallback)'),
 		];
 
+		$additionalCoreTemplates = $this->getAdditionalCoreTemplates(
+			[
+				'core/templates/html.mail.footer.php' =>
+					$this->l10n->t('Common email footer (HTML)'),
+				'core/templates/plain.mail.footer.php' =>
+					$this->l10n->t('Common email footer (plain text)'),
+			]
+		);
+
 		$activityTemplates = $this->getAppTemplates(
 			'activity',
 			[
@@ -128,6 +137,7 @@ class TemplateEditor {
 		);
 		$templates = \array_merge(
 			$templates,
+			$additionalCoreTemplates,
 			$activityTemplates,
 			$notificationsTemplates
 		);
@@ -136,9 +146,24 @@ class TemplateEditor {
 	}
 
 	/**
+	 * @param string[] $templates
+	 * @return string[]
+	 */
+	public function getAdditionalCoreTemplates($templates) {
+		$serverRoot = $this->environmentHelper->getServerRoot();
+		$existingTemplates = [];
+		foreach ($templates as $templatePath => $templateTitle) {
+			if ($this->fileExists($serverRoot . '/' . $templatePath)) {
+				$existingTemplates[$templatePath] = $templateTitle;
+			}
+		}
+		return $existingTemplates;
+	}
+
+	/**
 	 * @param string $appId
 	 * @param string[] $templates
-	 * @return array
+	 * @return string[]
 	 */
 	protected function getAppTemplates($appId, $templates) {
 		$appTemplates = [];

--- a/tests/unit/TemplateEditorTest.php
+++ b/tests/unit/TemplateEditorTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace OCA\TemplateEditor\Tests\Unit;
+
+use OC\Helper\EnvironmentHelper;
+use OCA\TemplateEditor\TemplateEditor;
+use OCP\App\IAppManager;
+use OCP\IL10N;
+use OCP\Theme\IThemeService;
+use Test\TestCase;
+
+class TemplateEditorTest extends TestCase {
+
+	/**
+	 * @var IThemeService | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $themeService;
+
+	/**
+	 * @var IAppManager | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $appManager;
+
+	/**
+	 * @var EnvironmentHelper | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $environmentHelper;
+
+	/**
+	 * @var IL10N | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $l10n;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->themeService = $this->getMockBuilder(IThemeService::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->appManager = $this->getMockBuilder(IAppManager::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->environmentHelper = $this->getMockBuilder(EnvironmentHelper::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->l10n = $this->getMockBuilder(IL10N::class)
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testBaseTemplates() {
+		$templateEditor = new TemplateEditor(
+			$this->themeService,
+			$this->appManager,
+			$this->environmentHelper,
+			$this->l10n
+		);
+
+		$templates = $templateEditor->getEditableTemplates();
+		$this->assertEquals(7, count($templates));
+	}
+
+	public function testBaseAndFooterTemplates() {
+		$serverRoot = '/var/www';
+		$templateEditor = $this->getMockBuilder(TemplateEditor::class)
+			->setConstructorArgs(
+				[
+					$this->themeService,
+					$this->appManager,
+					$this->environmentHelper,
+					$this->l10n
+				]
+			)
+			->setMethods(['fileExists'])
+			->getMock();
+
+		$this->environmentHelper->expects($this->any())
+			->method('getServerRoot')
+			->willReturn($serverRoot);
+
+		$templateEditor->expects($this->any())
+			->method('fileExists')
+			->willReturnCallback(
+				function ($path) use ($serverRoot) {
+					return in_array(
+						$path,
+						[
+							$serverRoot . '/core/templates/html.mail.footer.php',
+							$serverRoot . '/core/templates/plain.mail.footer.php'
+						]
+					);
+				}
+			);
+
+		$templates = $templateEditor->getEditableTemplates();
+		$this->assertEquals(9, count($templates));
+	}
+}

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+
+if (!\defined('PHPUNIT_RUN')) {
+	\define('PHPUNIT_RUN', 1);
+}
+
+require_once __DIR__.'/../../../../lib/base.php';
+
+\OC::$composerAutoloader->addPsr4('Test\\', OC::$SERVERROOT . '/tests/lib/', true);
+\OC::$composerAutoloader->addPsr4('Tests\\', OC::$SERVERROOT . '/tests/', true);
+
+if (!\class_exists('PHPUnit_Framework_TestCase')) {
+	require_once('PHPUnit/Autoload.php');
+}
+
+\OC_App::loadApp('templateeditor');

--- a/tests/unit/phpunit.xml
+++ b/tests/unit/phpunit.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<phpunit bootstrap="bootstrap.php"
+		 verbose="true"
+		 timeoutForSmallTests="900"
+		 timeoutForMediumTests="900"
+		 timeoutForLargeTests="900"
+>
+	<testsuite name='ownCloud - Template Editor App Tests'>
+		<directory suffix='Test.php'>.</directory>
+	</testsuite>
+	<!-- filters for code coverage -->
+	<filter>
+		<whitelist>
+			<directory suffix=".php">../../</directory>
+			<exclude>
+				<directory suffix=".php">../../l10n</directory>
+				<directory suffix=".php">..</directory>
+			</exclude>
+		</whitelist>
+	</filter>
+	<logging>
+		<!-- and this is where your report will be written -->
+		<log type="coverage-clover" target="./clover.xml"/>
+	</logging>
+</phpunit>


### PR DESCRIPTION
- [x] https://github.com/owncloud/templateeditor/issues/70 Implement best practices in code
- [x] https://github.com/owncloud/templateeditor/issues/73 Add notification email templates to editable list
- [x] https://github.com/owncloud/templateeditor/issues/71 Add footer template to editable list
- [x] setup unit testing and add first unit test :)

Test cases:
- 10.0.8 should not offer edit mail footer templates
- 10.0.9+ should offer edit mail footer templates (HTML and plain)
- in case **notifications** app is enabled, it's mail templates should appear in the list too 