### PR TITLE
Adjust composer files and app core min-version for 'drop PHP 5.6'

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ For more information, please read the [ownCloud Documentation](https://doc.owncl
 	<screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/templateeditor/ownCloud-app-email-template-editor.jpg</screenshot>
 	<namespace>TemplateEditor</namespace>
 	<dependencies>
-		<owncloud min-version="10.0.9" max-version="10" />
+		<owncloud min-version="10.2" max-version="10" />
 	</dependencies>
 	<default_enable/>
 	<website>https://github.com/owncloud/templateeditor/</website>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "owncloud/templateeditor",
   "config" : {
     "platform": {
-      "php": "5.6.37"
+      "php": "7.0.8"
     }
   },
   "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9fa52c72c946f6f945176d86725496ea",
+    "content-hash": "1958206d05aa4c9c5d86c3b202276143",
     "packages": [],
     "packages-dev": [
         {
@@ -55,6 +55,6 @@
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6.37"
+        "php": "7.0.8"
     }
 }


### PR DESCRIPTION
- [x] adjust local `composer` files to PHP 7.0.8
- [x] bump app core min-version to `10.2`

because the app is now being tested only against core `stable10` upcoming `10.2` that has dropped PHP 5.6 support.
