### PR TITLE
Include additional "lostpassword" templates

### DIFF
--- a/lib/TemplateEditor.php
+++ b/lib/TemplateEditor.php
@@ -101,7 +101,13 @@ class TemplateEditor {
 			'core/templates/internalaltmail.php' =>
 				$this->l10n->t('Sharing email (plain text fallback)'),
 			'core/templates/lostpassword/email.php' =>
-				$this->l10n->t('Lost password mail'),
+				$this->l10n->t('Lost password mail (HTML)'),
+			'core/templates/lostpassword/altemail.php' =>
+				$this->l10n->t('Lost password mail (plain text fallback)'),
+			'core/templates/lostpassword/notify.php' =>
+				$this->l10n->t('Password changed notification mail (HTML)'),
+			'core/templates/lostpassword/altnotify.php' =>
+				$this->l10n->t('Password changed notification mail (plain text fallback)'),
 			'settings/templates/email.new_user.php' =>
 				$this->l10n->t('New user email (HTML)'),
 			'settings/templates/email.new_user_plain_text.php' =>

--- a/tests/unit/TemplateEditorTest.php
+++ b/tests/unit/TemplateEditorTest.php
@@ -59,7 +59,7 @@ class TemplateEditorTest extends TestCase {
 		);
 
 		$templates = $templateEditor->getEditableTemplates();
-		$this->assertEquals(7, \count($templates));
+		$this->assertEquals(10, \count($templates));
 	}
 
 	public function testBaseAndFooterTemplates() {
@@ -95,6 +95,6 @@ class TemplateEditorTest extends TestCase {
 			);
 
 		$templates = $templateEditor->getEditableTemplates();
-		$this->assertEquals(9, \count($templates));
+		$this->assertEquals(12, \count($templates));
 	}
 }


### PR DESCRIPTION
Added new email templates https://github.com/owncloud/enterprise/issues/4927

Note that the "core/templates/lostpassword/resetpassword.php" file isn't an email template but a web page, so I think it shouldn't be changed